### PR TITLE
Remove the MediaWiki header in page

### DIFF
--- a/ArchWiki/optimizer.py
+++ b/ArchWiki/optimizer.py
@@ -50,6 +50,9 @@ class Optimizer:
 
         # strip <script> tags
         lxml.etree.strip_elements(root, "script")
+        
+        # strip <header> tags
+        lxml.etree.strip_elements(root, "header")
 
     def fix_layout(self, root):
         """ fix page layout after removing some elements


### PR DESCRIPTION
There's still a lingering MediaWiki header in the downloaded pages:
![screen-2022-08-26-20-19-23](https://user-images.githubusercontent.com/22784008/186902530-3fa13929-0fb1-4655-8183-24883710b494.jpg)
Since its searching function is already stripped after downloading, it's useless and ugly at the same time. It is controlled solely by the `<header class="mw-header">` tag, so we could easily remove it.