### PR TITLE
Language filter bugs

### DIFF
--- a/ArchWiki/ArchWiki.py
+++ b/ArchWiki/ArchWiki.py
@@ -163,7 +163,7 @@ class ArchWiki(MediaWiki):
         if match:
             pure = match.group("pure")
             lang = match.group("lang")
-            if lang in self._language_names:
+            if lang in language_names:
                 # strip "(Language)" from all subpage components to handle cases like
                 # "Page name (Language)/Subpage (Language)"
                 if strip_all_subpage_parts is True and "/" in pure:
@@ -215,7 +215,7 @@ class ArchWiki(MediaWiki):
 
         path = pattern.format(
             base=basepath,
-            langsubtag=self._language_names[lang]["subtag"],
+            langsubtag=language_names[lang]["subtag"],
             namespace=namespace,
             title=title,
             ext="html"

--- a/ArchWiki/downloader.py
+++ b/ArchWiki/downloader.py
@@ -4,6 +4,7 @@ import os
 import datetime
 
 import requests
+from ArchWiki.ArchWiki import ArchWiki, language_names
 from requests.packages.urllib3.util.retry import Retry
 
 class Downloader:
@@ -70,6 +71,21 @@ class Downloader:
             return True
         return False
 
+    def check_language(self, fname):
+        """ check if the language in the fname path is in the list of desired languages
+        """
+        if not fname:
+            return False
+        
+        if language_names == self.wiki._language_names:
+            return True
+
+        flang = fname.split(os.sep)[1]
+        for lang in self.wiki._language_names:
+            if flang in self.wiki._language_names[lang]["subtag"]:
+                return True
+        return False
+
     def process_namespace(self, namespace):
         """ walk all pages in given namespace, download if necessary
         """
@@ -82,7 +98,7 @@ class Downloader:
             for page in sorted(pages_snippet["pages"].values(), key=lambda d: d["title"]):
                 title = page["title"]
                 fname = self.wiki.get_local_filename(title, self.output_directory)
-                if not fname:
+                if not self.check_language(fname):
                     print(f"  [skipping] {title}")
                     continue
                 self.files.append(fname)


### PR DESCRIPTION
There are bugs in the language filter:
- There isn't actually a check to see if the page should be downloaded with the given filter list
- Using the language filter puts all downloaded pages into the subdir /en/, combined with the bug above, it downloads pages in all languages in that subdir
- Using a language filter can cause a KeyError

I fixed everything and it seems to be working fine now.